### PR TITLE
Expose button height and font on host so they can be overriden

### DIFF
--- a/gaia-button.js
+++ b/gaia-button.js
@@ -68,9 +68,12 @@ module.exports = component.register('gaia-button', {
     :host {
       display: block;
       box-sizing: border-box;
+      height: 50px;
       min-width: 50%;
       margin: var(--base-m, 18px);
       outline: 0;
+      font-style: italic;
+      font-size: 17px;
     }
 
     @media(min-width:500px) {
@@ -87,7 +90,7 @@ module.exports = component.register('gaia-button', {
 
     .inner {
       position: relative;
-      height: 50px;
+      height: 100%;
       border-radius: 50px;
       overflow: hidden;
       cursor: pointer;
@@ -203,8 +206,6 @@ module.exports = component.register('gaia-button', {
       z-index: 2;
       height: 100%;
       padding: 0 18px;
-      font-style: italic;
-      font-size: 17px;
       pointer-events: none; /* 1 */
     }
 


### PR DESCRIPTION
Fixes issue #1 by exposing font-size and height on the host element rather than the shadow dom.
