### PR TITLE
show travis CI status and remove npm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# &lt;gaia-button&gt; [![devDependency Status](https://david-dm.org/gaia-components/gaia-header/dev-status.svg)](https://david-dm.org/gaia-components/gaia-button#info=devDependencies)
+# &lt;gaia-button&gt; [![](https://travis-ci.org/gaia-components/gaia-button.svg)](https://travis-ci.org/gaia-components/gaia-button) [![devDependency Status](https://david-dm.org/gaia-components/gaia-header/dev-status.svg)](https://david-dm.org/gaia-components/gaia-button#info=devDependencies)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
   },
   "browser": {
     "gaia-component": "./bower_components/gaia-component/gaia-component.js"
-  },
-  "dependencies": {
-    "gaia-component": "git://github.com/gaia-components/gaia-component.git"
   }
 }


### PR DESCRIPTION
@KevinGrandon could you help enable all travis integration for gaia web components? So we could see auto lint status and maybe future unit tests result there.
